### PR TITLE
Change map() to list comprehension for Python 3 compatibility

### DIFF
--- a/virtualbox/library_ext/guest_session.py
+++ b/virtualbox/library_ext/guest_session.py
@@ -89,7 +89,7 @@ class IGuestSession(library.IGuestSession):
             flag_none = [library.ProcessInputFlag.none]
             flag_eof = [library.ProcessInputFlag.end_of_file]
             while index < len(stdin):
-                array = map(lambda a: str(ord(a)), stdin[index:])
+                array = [str(ord(a)) for a in stdin[index:]]
                 wrote = process.write_array(0, flag_none, array, 0)
                 if wrote == 0:
                     raise Exception("Failed to write ANY bytes to %s" % process)


### PR DESCRIPTION
map() was changed in Python 3 to return an iterator instead of a list, while process.write_array expects a list. This pull request fixes this by using a list comprehension instead of map().