### PR TITLE
Close partially opened guest session when IGuest.create_session() fails

### DIFF
--- a/virtualbox/library_ext/guest.py
+++ b/virtualbox/library_ext/guest.py
@@ -23,6 +23,10 @@ class IGuest(library.IGuest):
                 break
             time.sleep(0.1)
         else:
+            # Wait for session termination
+            if session is not None:
+                session.close()
+                session.wait_for(int(library.GuestSessionWaitForFlag.terminate), timeout_ms=timeout_ms)
             if len(password) == 0:
                 raise SystemError(
                     "GuestSession failed to start. Could be because "

--- a/virtualbox/library_ext/guest.py
+++ b/virtualbox/library_ext/guest.py
@@ -26,7 +26,7 @@ class IGuest(library.IGuest):
             # Wait for session termination
             if session is not None:
                 session.close()
-                session.wait_for(int(library.GuestSessionWaitForFlag.terminate), timeout_ms=timeout_ms)
+                session.wait_for(int(library.GuestSessionWaitForFlag.terminate), timeout_ms=5000)
             if len(password) == 0:
                 raise SystemError(
                     "GuestSession failed to start. Could be because "


### PR DESCRIPTION
Ensures that guest sessions created with IGuest.create_session() are properly closed in case of failure. Closes #101.